### PR TITLE
make create idempotent

### DIFF
--- a/scripts/generate-tfvars.sh
+++ b/scripts/generate-tfvars.sh
@@ -33,9 +33,7 @@ TFVARS_FILE="$ROOT/terraform/terraform.tfvars"
 
 if [[ -f "${TFVARS_FILE}" ]]
 then
-    echo "${TFVARS_FILE} already exists." 1>&2
-    echo "Please remove or rename before regenerating." 1>&2
-    exit 1;
+    echo "${TFVARS_FILE} already exists, skipping generation."
 else
     cat <<EOF > "${TFVARS_FILE}"
 project="${PROJECT}"


### PR DESCRIPTION
`make create` Can now be run twice in a row without error. Also, a create can be run after a teardown. To test:

```
make create
# Optionally modify TF files.
make create
# Should finish successfully, applying TF changes if any.

make teardown
make create
```

I recommend we also make `make teardown` idempotent. Currently it fails if the terraform project has not been initialized. However, it should detect this and continue to clean any other remains of of past use, deleting terraform.tfvars, etc. and exiting cleanly.