### PR TITLE
Moving .bigqueryrc file creation to the Jenkinsfile

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -66,6 +66,9 @@ spec:
           sh "gcloud config set compute/zone ${env.ZONE}"
           sh "gcloud config set core/project ${env.PROJECT_ID}"
           sh "gcloud config set compute/region ${env.REGION}"
+
+          // Set auth for bq so we don't get prompted
+          sh 'echo "credential_file=${GOOGLE_APPLICATION_CREDENTIALS}" > /home/jenkins/.bigqueryrc'
          }
     }
     stage('Lint') {

--- a/scripts/teardown.sh
+++ b/scripts/teardown.sh
@@ -30,9 +30,6 @@ ROOT="$( cd "$( dirname "${BASH_SOURCE[0]}" )/.." && pwd )"
 # shellcheck source=scripts/common.sh
 source "$ROOT"/scripts/common.sh
 
-# Set auth for bq so we don't get prompted
-echo "credential_file = ${GOOGLE_APPLICATION_CREDENTIALS}" > /home/jenkins/.bigqueryrc
-
 # We have to delete the dataset before the Terraform
 # Otherwise we will run into the following error
 # "google_bigquery_dataset.gke-bigquery-dataset: googleapi:


### PR DESCRIPTION
Since we should only need to create the file .bigqueryrc on the build server I moved it to the Jenkinsfile. We don't want users running the teardown script and potentially overwriting their .bigqueryrc file