### PR TITLE
needed for TF 0.12 and newer Google provider

### DIFF
--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -55,7 +55,7 @@ resource "google_bigquery_dataset" "gke-bigquery-dataset" {
   location                    = "US"
   default_table_expiration_ms = 3600000
 
-  labels {
+  labels = {
     env = "default"
   }
 }

--- a/terraform/provider.tf
+++ b/terraform/provider.tf
@@ -18,5 +18,5 @@ limitations under the License.
 // Configles the Google Cloud Provider with default settings
 provider "google" {
   project = "${var.project}"
-  version = "~> 1.13"
+  version = "~> 2.5"
 }


### PR DESCRIPTION
Changes needed to make the demo work with TF 0.12. The old Google provider appears to not work, so had to update that as well.