### PR TITLE
Change zone as location

### DIFF
--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -26,8 +26,8 @@ limitations under the License.
 // Provides access to available Google Container Engine versions in a zone for a given project.
 // https://www.terraform.io/docs/providers/google/d/google_container_engine_versions.html
 data "google_container_engine_versions" "on-prem" {
-  zone    = var.zone
-  project = var.project
+  location = var.zone
+  project  = var.project
 }
 
 ///////////////////////////////////////////////////////////////////////////////////////
@@ -68,7 +68,7 @@ resource "google_bigquery_dataset" "gke-bigquery-dataset" {
 // https://www.terraform.io/docs/providers/google/d/google_container_cluster.html
 resource "google_container_cluster" "primary" {
   name               = "stackdriver-logging"
-  zone               = var.zone
+  location           = var.zone
   initial_node_count = 2
   min_master_version = data.google_container_engine_versions.on-prem.latest_master_version
 
@@ -84,7 +84,7 @@ resource "google_container_cluster" "primary" {
   // These local-execs are used to provision the sample service
   // These local-execs are used to provision the sample service
   provisioner "local-exec" {
-    command = "gcloud container clusters get-credentials ${google_container_cluster.primary.name} --zone ${google_container_cluster.primary.zone} --project ${var.project}"
+    command = "gcloud container clusters get-credentials ${google_container_cluster.primary.name} --zone ${google_container_cluster.primary.location} --project ${var.project}"
   }
 
   provisioner "local-exec" {


### PR DESCRIPTION
This pull request fixes the issue #34.
```
student_01_5baa690b0dc9@cloudshell:~/gke-logging-sinks-demo (qwiklabs-gcp-01-3d7a402c8541)$ make create
Your active configuration is: [cloudshell-20845]
Your active configuration is: [cloudshell-20845]
Your active configuration is: [cloudshell-20845]
Operation "operations/acf.bd9e8ec9-7091-4ef0-89ce-b7f78ad3997c" finished successfully.
Your active configuration is: [cloudshell-20845]
Your active configuration is: [cloudshell-20845]
Your active configuration is: [cloudshell-20845]

Initializing the backend...

Initializing provider plugins...

The following providers do not have any version constraints in configuration,
so the latest version was installed.

To prevent automatic upgrades to new major versions that may contain breaking
changes, it is recommended to add version = "..." constraints to the
corresponding provider blocks in configuration, with the constraint strings
suggested below.

* provider.google: version = "~> 3.3"
* provider.random: version = "~> 2.2"

Terraform has been successfully initialized!

You may now begin working with Terraform. Try running "terraform plan" to see
any changes that are required for your infrastructure. All Terraform commands
should now work.

If you ever set or change modules or backend configuration for Terraform,
rerun this command to reinitialize your working directory. If you forget, other
commands will detect it and remind you to do so if necessary.
data.google_container_engine_versions.on-prem: Refreshing state...
random_id.server: Creating...
random_id.server: Creation complete after 0s [id=c2zUtiPc7MI]
google_container_cluster.primary: Creating...
google_bigquery_dataset.gke-bigquery-dataset: Creating...
google_storage_bucket.gke-log-bucket: Creating...
google_storage_bucket.gke-log-bucket: Creation complete after 1s [id=stackdriver-gke-logging-bucket-736cd4b623dcecc2]
google_logging_project_sink.storage-sink: Creating...
google_bigquery_dataset.gke-bigquery-dataset: Creation complete after 1s [id=projects/qwiklabs-gcp-01-3d7a402c8541/datasets/gke_logs_dataset]
google_logging_project_sink.bigquery-sink: Creating...
google_logging_project_sink.bigquery-sink: Creation complete after 4s [id=projects/qwiklabs-gcp-01-3d7a402c8541/sinks/gke-bigquery-sink]
google_project_iam_binding.log-writer-bigquery: Creating...
google_logging_project_sink.storage-sink: Creation complete after 5s [id=projects/qwiklabs-gcp-01-3d7a402c8541/sinks/gke-storage-sink]
google_project_iam_binding.log-writer-storage: Creating...
google_container_cluster.primary: Still creating... [10s elapsed]
google_project_iam_binding.log-writer-bigquery: Still creating... [10s elapsed]
google_project_iam_binding.log-writer-storage: Still creating... [10s elapsed]
google_container_cluster.primary: Still creating... [20s elapsed]
google_project_iam_binding.log-writer-storage: Creation complete after 16s [id=qwiklabs-gcp-01-3d7a402c8541/roles/storage.objectCreator]
google_project_iam_binding.log-writer-bigquery: Creation complete after 17s [id=qwiklabs-gcp-01-3d7a402c8541/roles/bigquery.dataEditor]
google_container_cluster.primary: Still creating... [30s elapsed]
google_container_cluster.primary: Still creating... [40s elapsed]
google_container_cluster.primary: Still creating... [50s elapsed]
google_container_cluster.primary: Still creating... [1m0s elapsed]
google_container_cluster.primary: Still creating... [1m10s elapsed]
google_container_cluster.primary: Still creating... [1m20s elapsed]
google_container_cluster.primary: Still creating... [1m30s elapsed]
google_container_cluster.primary: Still creating... [1m40s elapsed]
google_container_cluster.primary: Still creating... [1m50s elapsed]
google_container_cluster.primary: Still creating... [2m0s elapsed]
google_container_cluster.primary: Still creating... [2m10s elapsed]
google_container_cluster.primary: Still creating... [2m20s elapsed]
google_container_cluster.primary: Still creating... [2m30s elapsed]
google_container_cluster.primary: Still creating... [2m40s elapsed]
google_container_cluster.primary: Still creating... [2m50s elapsed]
google_container_cluster.primary: Still creating... [3m0s elapsed]
google_container_cluster.primary: Provisioning with 'local-exec'...
google_container_cluster.primary (local-exec): Executing: ["/bin/sh" "-c" "gcloud container clusters get-credentials stackdriver-logging --zone us-central1-a --project qwiklabs-gcp-01-3d7a402c8541"]
google_container_cluster.primary (local-exec): Fetching cluster endpoint and auth data.
google_container_cluster.primary (local-exec): kubeconfig entry generated for stackdriver-logging.
google_container_cluster.primary: Provisioning with 'local-exec'...
google_container_cluster.primary (local-exec): Executing: ["/bin/sh" "-c" "kubectl --namespace default run hello-server --image gcr.io/google-samples/hello-app:1.0 --port 8080"]
google_container_cluster.primary (local-exec): kubectl run --generator=deployment/apps.v1 is DEPRECATED and will be removed in a future version. Use kubectl run --generator=run-pod/v1 or kubectl create instead.
google_container_cluster.primary (local-exec): deployment.apps/hello-server created
google_container_cluster.primary: Provisioning with 'local-exec'...
google_container_cluster.primary (local-exec): Executing: ["/bin/sh" "-c" "kubectl --namespace default expose deployment hello-server --type \"LoadBalancer\" "]
google_container_cluster.primary: Still creating... [3m10s elapsed]
google_container_cluster.primary (local-exec): service/hello-server exposed
google_container_cluster.primary: Creation complete after 3m10s [id=projects/qwiklabs-gcp-01-3d7a402c8541/locations/us-central1-a/clusters/stackdriver-logging]

Apply complete! Resources: 8 added, 0 changed, 0 destroyed.
```